### PR TITLE
Update Origin Trial information to reflect extension

### DIFF
--- a/OriginTrialStatus.md
+++ b/OriginTrialStatus.md
@@ -1,7 +1,7 @@
 ## Origin Trial Status of `scheduler.postTask`
 
 We're running an [Origin
-Trial](https://www.chromium.org/blink/origin-trials) in Chrome 86&ndash;87 to allow
+Trial](https://www.chromium.org/blink/origin-trials) in Chrome 88&ndash;89 to allow
 testing this API in the wild (you can register [here](https://developers.chrome.com/origintrials/#/view_trial/2650368380707536897)).
 
 This page tracks the current status of what parts of the APIs are implemented


### PR DESCRIPTION
The postTask Origin Trial was recently extended for 2 milestones (through M89), so I'm updating the OT info page.