### PR TITLE
Clean up yield inheritance

### DIFF
--- a/spec/patches.md
+++ b/spec/patches.md
@@ -32,8 +32,30 @@ determine task execution order across [=scheduler task queues=] of the same {{Ta
 all {{Scheduler}}s associated with the same [=event loop=]. A timestamp would also suffice as long
 as it is guaranteed to be strictly increasing and unique.
 
-Add: An [=event loop=] has a <dfn for="event loop">current scheduling state</dfn> (a [=scheduling
-state=] or null), which is initialized to null.
+Add: An [=event loop=] has a <dfn for="event loop">current continuation state</dfn> (a
+[=continuation state=] or null), which is initially null.
+
+Add the following algorithms:
+
+<div algorithm>
+  To <dfn>set the continuation state value</dfn> for |key| to |value| given an |eventLoop| (an
+  [=event loop=]):
+
+  1. If |eventLoop|'s [=event loop/current continuation state=] is null, then set |eventLoop|'s
+     [=event loop/current continuation state=] to a new [=continuation state=].
+  1. Let |continuationState| be |eventLoop|'s [=event loop/current continuation state=].
+  1. Assert: |continuationState|'s [=continuation state/state map=][|key|] does not [=map/exist=].
+  1. Set |continuationState|'s [=continuation state/state map=][|key|] to |value|.
+</div>
+
+<div algorithm>
+  To <dfn>get the continuation state value</dfn> for |key| given an |eventLoop| (an [=event loop=]):
+
+  1. Let |continuationState| be |eventLoop|'s [=event loop/current continuation state=].
+  1. If |continuationState| is not null and |continuationState|'s
+     [=continuation state/state map=][|key|] [=map/exists=], then return |continuationState|'s
+     [=continuation state/state map=][|key|], otherwise return null.
+</div>
 
 ### <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model">Event loop: processing model</a> ### {#sec-patches-html-event-loop-processing}
 
@@ -80,20 +102,36 @@ Issue: The |taskQueue| in this step will either be a [=set=] of [=tasks=] or a [
 *roughly* compatible. Ideally, there would be a common task queue interface that supports a `pop()`
 method that would return a plain [=task=], but that would involve a fair amount of refactoring.
 
+### <a href="https://html.spec.whatwg.org/#queuing-tasks">Event Loop: Queuing Tasks</a> ### {#sec-patches-html-queuing-tasks}
+
+Change the <a href="">To queue a microtask</a> algorithm to accept an optional boolean
+|ignoreContinuationState| (default false).
+
+Change Step 5 to the following:
+
+  1. Let |continuationState| be |eventLoop|'s [=event loop/current continuation state=] if
+     |ignoreContinuationState| is false, otherwise null.
+  1. Set <var ignore=''>microtask</var>'s <a attribute for="task">steps</a> to the following:
+    1. If |ignoreContinuationState| is false, then set |eventLoop|'s
+       [=event loop/current continuation state=] to |continuationState|.
+    1. Run <var ignore=''>steps</var>.
+    1. If |ignoreContinuationState| is false, then set |eventLoop|'s
+       [=event loop/current continuation state=] to null.
+
 ### <a href="https://html.spec.whatwg.org/multipage/webappapis.html#hostmakejobcallback">HostMakeJobCallback(callable)</a> ### {#sec-patches-html-hostmakejobcallback}
 
 Add the following before step 5:
 
   1. Let |event loop| be <var ignore=''>incumbent settings<var>'s
      [=environment settings object/realm=]'s [=realm/agent=]'s [=agent/event loop=].
-  1. Let |state| be |event loop|'s [=event loop/current scheduling state=].
+  1. Let |state| be |event loop|'s [=event loop/current continuation state=].
 
 Modify step 5 to read:
 
  1. Return the <span>JobCallback Record</span> { \[[Callback]]: <var ignore=''>callable</var>,
     \[[HostDefined]]: { \[[IncumbentSettings]]: <var ignore=''>incumbent settings</var>,
     \[[ActiveScriptContext]]: <var ignore=''>script execution context</var>,
-    \[[SchedulingState]]: |state| } }.
+    \[[ContinuationState]]: |state| } }.
 
 ### <a href="https://html.spec.whatwg.org/multipage/webappapis.html#hostcalljobcallback">HostCallJobCallback(callback, V, argumentsList)</a> ### {#sec-patches-html-hostcalljobcallback}
 
@@ -101,12 +139,18 @@ Add the following steps before step 5:
 
   1. Let |event loop| be <var ignore=''>incumbent settings<var>'s
      [=environment settings object/realm=]'s [=realm/agent=]'s [=agent/event loop=].
-  1. Set |event loop|'s [=event loop/current scheduling state=] to
-     <var ignore=''>callback</var>.\[[HostDefined]].\[[SchedulingState]].
+  1. Set |event loop|'s [=event loop/current continuation state=] to
+     <var ignore=''>callback</var>.\[[HostDefined]].\[[ContinuationState]].
 
 Add the following after step 7:
 
-  1. Set |event loop|'s [=event loop/current scheduling state=] to null.
+  1. Set |event loop|'s [=event loop/current continuation state=] to null.
+
+### <a href="https://html.spec.whatwg.org/multipage/webappapis.html#hostenqueuepromisejob">HostEnqueuePromiseJob(job, realm)</a> ### {#sec-patches-html-hostenqueuepromisejob}
+
+Change step 2 to:
+
+ 1. Queue a microtask to perform the following steps with |ignoreContinuationState| set to true:
 
 ## <a href="https://w3c.github.io/requestidlecallback/">`requestIdleCallback()`</a> ## {#sec-patches-requestidlecallback}
 
@@ -118,9 +162,9 @@ Add the following step before step 3.3:
   1. Let |state| be a new [=scheduling state=].
   1. Set |state|'s [=scheduling state/priority source=] to the result of [=creating a fixed priority
      unabortable task signal=] given "{{TaskPriority/background}}" and |realm|.
-  1. Let |event loop| be |realm|'s [=realm/agent=]'s [=agent/event loop=].
-  1. Set |event loop|'s [=event loop/current scheduling state=] to |state|.
+  1. Let |scheduler| be the {{Scheduler}} whose [=relevant realm=] is |realm|.
+  1. [=Set the current scheduling state=] for |scheduler| to |state|.
 
 Add the following after step 3.3:
 
-  1. Set |event loop|'s [=event loop/current scheduling state=] to null.
+  1. Set |event loop|'s [=event loop/current continuation state=] to null.

--- a/spec/patches.md
+++ b/spec/patches.md
@@ -104,13 +104,15 @@ method that would return a plain [=task=], but that would involve a fair amount 
 
 ### <a href="https://html.spec.whatwg.org/#queuing-tasks">Event Loop: Queuing Tasks</a> ### {#sec-patches-html-queuing-tasks}
 
-Change the <a href="">To queue a microtask</a> algorithm to accept an optional boolean
-|ignoreContinuationState| (default false).
+Change the <a href="https://html.spec.whatwg.org/#queue-a-microtask">To queue a microtask</a>
+algorithm to accept an optional boolean |ignoreContinuationState| (default false).
 
 Change Step 5 to the following:
 
-  1. Let |continuationState| be |eventLoop|'s [=event loop/current continuation state=] if
-     |ignoreContinuationState| is false, otherwise null.
+  1. Let |continuationState| be null.
+  1. If |ignoreContinuationState| is false and |eventLoop|'s
+     [=event loop/current continuation state=] is not null, then set |continuationState| to the
+     result of [=list/cloning=] |event loop|'s [=event loop/current continuation state=].
   1. Set <var ignore=''>microtask</var>'s <a attribute for="task">steps</a> to the following:
     1. If |ignoreContinuationState| is false, then set |eventLoop|'s
        [=event loop/current continuation state=] to |continuationState|.
@@ -124,7 +126,9 @@ Add the following before step 5:
 
   1. Let |event loop| be <var ignore=''>incumbent settings<var>'s
      [=environment settings object/realm=]'s [=realm/agent=]'s [=agent/event loop=].
-  1. Let |state| be |event loop|'s [=event loop/current continuation state=].
+  1. Let |state| be the result of [=list/cloning=] |event loop|'s
+     [=event loop/current continuation state=] if [=event loop/current continuation state=] is not
+     null, or otherwise null.
 
 Modify step 5 to read:
 


### PR DESCRIPTION
1. Key the scheduling state based on the {{Scheduler}} to prevent leaking it across (potentially cross-origin) windows. This changes the event loop's continuation state to be a small wrapper around a map. The continuation state is propagated in the same way, but the scheduler state is unique to the scheduler and not shared. In practice there will only be one entry in this map (a task or microtask can only have originated from one task), but the mechanism is generic enough to support other use cases, implementations can optimize this, and the key/value mapping hopefully makes the isolation clear.

    Alternatively, we could propagate only the state for the current scheduler, but we don't always know the current scheduler, e.g. in "queue a microtask", and this model is different enough from AsyncContext and Chrome's "Task Attribution" that we'd need a separate mechanism, which is a performance concern. The main behavioral difference is how propagating is handled in the case of A --> (B microtask) --> A. With this approach, the context is preserved in the second call to A, which matches the synchronous behavior of A --> calls B --> calls A.

 2. Propagate the current scheduling state in "queue a microtask", unless coming from JavaScript, in which case the propagation is handled by the abstract job closure. Previously, the state would be inherited only if it wasn't reset by another microtask or after the postTask callback ran. This fixes the inconsistency, making directly scheduled microtasks match microtasks originating from JavaScript.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shaseley/scheduling-apis/pull/115.html" title="Last updated on May 2, 2025, 8:52 PM UTC (fc1e040)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/scheduling-apis/115/83873f3...shaseley:fc1e040.html" title="Last updated on May 2, 2025, 8:52 PM UTC (fc1e040)">Diff</a>